### PR TITLE
:sparkles: brewディレクトリの設定方法の変更

### DIFF
--- a/.profile
+++ b/.profile
@@ -19,19 +19,24 @@ export LC_CTYPE="ja_JP.UTF-8"
 export LC_TIME="ja_JP.UTF-8"
 
 # homebrew
-eval "$($HOME/.linuxbrew/bin/brew shellenv)"
+BREW_DIR="/home/linuxbrew"
+if [ -d "$HOME/.linuxbrew" ]; then
+    BREW_DIR="$HOME"
+fi
+
+eval "$($BREW_DIR/.linuxbrew/bin/brew shellenv)"
 export HOMEBREW_BUNDLE_FILE=~/.Brewfile
 
 export HOMEBREW_FORCE_BREWED_CURL=1
 export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1
 
 # uiwsgi用？
-# export LDFLAGS="-L$HOME/.linuxbrew/opt/openssl@1.1/lib  -L$HOME/.linuxbrew/opt/libffi/lib"
-# export LDFLAGS="-L$HOME/.linuxbrew/opt/openssl@1.1/lib  -L$HOME/.linuxbrew/opt/libffi/lib -L$HOME/.linuxbrew/opt/util-linux/lib"
-# export CPPFLAGS="-I$HOME/.linuxbrew/opt/openssl@1.1/include  -I$HOME/.linuxbrew/opt/libffi/include"
+# export LDFLAGS="-L$BREW_DIR/.linuxbrew/opt/openssl@1.1/lib  -L$BREW_DIR/.linuxbrew/opt/libffi/lib"
+# export LDFLAGS="-L$BREW_DIR/.linuxbrew/opt/openssl@1.1/lib  -L$BREW_DIR/.linuxbrew/opt/libffi/lib -L$BREW_DIR/.linuxbrew/opt/util-linux/lib"
+# export CPPFLAGS="-I$BREW_DIR/.linuxbrew/opt/openssl@1.1/include  -I$BREW_DIR/.linuxbrew/opt/libffi/include"
 
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/.linuxbrew/lib"
-export C_INCLUDE_PATH="$C_INCLUDE_PATH:$HOME/.linuxbrew/include"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BREW_DIR/.linuxbrew/lib"
+export C_INCLUDE_PATH="$C_INCLUDE_PATH:$BREW_DIR/.linuxbrew/include"
 
 # anyenv
 if [[ $SHELL == `which zsh` ]] ; then


### PR DESCRIPTION
linux用brewのインストール場所を変更したためBREW_DIRの設定方法を変更した。